### PR TITLE
Allow sysroots and test multiple _FORTIFY_SOURCE levels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,12 @@ else
 	USE_SYSROOT =
 endif
 
+ifeq (1,$(V))
+	Q =
+else
+	Q = @
+endif
+
 DEFAULT_CFLAGS = $(CFLAGS) -O1 $(USE_SYSROOT)
 CFLAGS_STATIC=$(DEFAULT_CFLAGS) -DSTATIC_CHECK -Werror
 STATIC_CHECK ?= false
@@ -43,10 +49,10 @@ run_%:$(foreach l,$(FORTIFY_LEVELS),runone_%_$(l))
 	true
 
 runone_%:test_%
-	./$<
-	! ./$< 1 1 1
-	! ./$< 1 1 1 1
-	@echo "$< OK"
+	$(Q)./$<
+	$(Q)! ./$< 1 1 1
+	$(Q)! ./$< 1 1 1 1
+	$(Q)echo "$< OK"
 
 static-build-cmd = ! $$(STATIC_CHECK) || $(1) \
 		-D_FORTIFY_SOURCE=$(2) $$(CFLAGS_STATIC) $$< 2>&1 \
@@ -55,7 +61,7 @@ static-build-cmd = ! $$(STATIC_CHECK) || $(1) \
 build-cmd = $(1) -D_FORTIFY_SOURCE=$(2) $$(DEFAULT_CFLAGS) $$< -o $$@
 
 build-target = test_%.$(1)_$(2):test_%.c; \
-	$(call static-build-cmd,$(1),$(2)) \
+	$(Q)$(call static-build-cmd,$(1),$(2)) \
 	$(call build-cmd,$(1),$(2))
 
 $(call build-target,gcc,1)

--- a/Makefile
+++ b/Makefile
@@ -62,12 +62,12 @@ $(foreach c,$(COMPILERS),$(foreach l,$(FORTIFY_LEVELS),$(eval \
 	$(call build-target,$(c),$(l)))))
 
 clean:
-	for target in $(TARGETS); do $(RM) $(patsubst %,$$target.%,$(COMPILERS)) ; done
+	for target in $(TARGETS); do $(RM) $(patsubst %,test_$$target.%*,$(COMPILERS)) ; done
 	$(RM) $(PKGNAME).tgz
 
 dist: $(PKGNAME).tgz
 
-$(PKGNAME).tgz: $(patsubst %,%.c, $(TARGETS)) Makefile README.rst
+$(PKGNAME).tgz: $(patsubst %,test_%.c, $(TARGETS)) Makefile README.rst
 	$(RM) -rf $(PKGNAME)
 	mkdir $(PKGNAME)
 	cp $^ $(PKGNAME)/

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,13 @@
 PKGNAME=fortify-test-suite
 
-CFLAGS ?=-D_FORTIFY_SOURCE=1 -O1
-CFLAGS_STATIC=$(CFLAGS) -DSTATIC_CHECK -Werror
+ifdef SYSROOT
+	USE_SYSROOT = -isysroot $(SYSROOT)
+else
+	USE_SYSROOT =
+endif
+
+DEFAULT_CFLAGS = $(CFLAGS) -D_FORTIFY_SOURCE -O1 $(USE_SYSROOT)
+CFLAGS_STATIC=$(DEFAULT_CFLAGS) -DSTATIC_CHECK -Werror
 STATIC_CHECK ?= false
 COMPILERS = gcc clang
 
@@ -40,7 +46,7 @@ run_%:test_%
 build-target = test_%.$(1):test_%.c; \
 	! $(STATIC_CHECK) || $(1) $(CFLAGS_STATIC) $< 2>&1 \
 		| grep ' error: '; \
-	$(1) $(CFLAGS) $$< -o $$@;
+	$(1) $(DEFAULT_CFLAGS) $$< -o $$@;
 
 $(call build-target,gcc)
 $(call build-target,clang)

--- a/README.rst
+++ b/README.rst
@@ -2,10 +2,10 @@ Test suite for __builtin_*_chk
 ==============================
 
 A collection of tests for compiler who wants to support glibc's fortify feature,
-the one triggered by ``-D_FORTIFY_SOURCE=1``.
+the one triggered by `-D_FORTIFY_SOURCE=1` or `-D_FORTIFY_SOURCE=2`.
 
 This tests compile time and runtime behavior of a few functions that involve
-call to compiler builtins like ``__builtin_memcpy_chk``.
+call to compiler builtins like `__builtin_memcpy_chk`.
 
 To run the whole suite:
 
@@ -24,4 +24,9 @@ To run the whole suite:
     # run only dynamic checks
     make check STATIC_CHECK=false
 
-The makefile is relatively generic, if one wants to test another compiler...
+    # run tests for specific functions, e.g. memcpy
+    make test-memcpy
+
+To test another compiler, add its name in the `COMPILERS` variable in the
+Makefile and ensure that it is in `PATH`; then for a compiler `CC`, its tests
+can be invoked using `make check-CC`.


### PR DESCRIPTION
This changeset adds the following:

- a SYSROOT option to allow testing glibc fortify headers installed in a different sysroot; it basically passes a -isysroot flag to the compiler

- Test both `-D_FORTIFY_SOURCE=1` and `-D_FORTIFY_SOURCE=2`.   I tried to auto-generate targets per fortify level but it didn't work, so for now they're hard coded.  Not a big deal though since one only needs to add one line per compiler for an additional fortification level.