### PR TITLE
Handle SIGABRT in tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ FORTIFY_LEVELS = 1 2
 
 TARGETS=memcpy memmove mempcpy memset snprintf sprintf stpcpy strcat strcpy strncat strncpy vsnprintf vsprintf
 
-check:$(patsubst %,check-%,$(COMPILERS))
+check:$(patsubst %,check-%,$(COMPILERS)) test_common.c
 
 define check-target =
 check-$(1):$(patsubst %,run_%.$(1),$(TARGETS))
@@ -37,12 +37,12 @@ endef
 $(foreach t,$(TARGETS),$(eval $(call check-single,$(t))))
 
 run_%:$(foreach l,$(FORTIFY_LEVELS),runone_%_$(l))
-	true
+	@true
 
 runone_%:test_%
-	$(Q)./$<
-	$(Q)! ./$< 1 1 1
-	$(Q)! ./$< 1 1 1 1
+	$(Q)./$< > /dev/null
+	$(Q)./$< 1 1 1 > /dev/null
+	$(Q)./$< 1 1 1 1 > /dev/null
 	$(Q)echo "$< OK"
 
 static-build-cmd = ! $$(STATIC_CHECK) || $(1) \

--- a/test_common.c
+++ b/test_common.c
@@ -1,0 +1,60 @@
+/* Copyright (C) 2004-2020 Free Software Foundation, Inc.
+   This snippet is taken from debug/tst-chk1 in the GNU C Library.
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library; if not, see
+   <https://www.gnu.org/licenses/>.  */
+
+#include <setjmp.h>
+#include <unistd.h>
+#include <signal.h>
+
+volatile int chk_fail_ok;
+volatile int ret;
+jmp_buf chk_fail_buf;
+
+static void
+handler (int sig)
+{
+  if (chk_fail_ok)
+    {
+      chk_fail_ok = 0;
+      longjmp (chk_fail_buf, 1);
+    }
+  else
+    _exit (127);
+}
+
+void
+__attribute__((constructor))
+set_fortify_handler (void)
+{
+  struct sigaction sa;
+
+  sa.sa_handler = handler;
+  sa.sa_flags = 0;
+  sigemptyset (&sa.sa_mask);
+
+  sigaction (SIGABRT, &sa, NULL);
+}
+
+#define FAIL() \
+  do { fprintf (stderr, "Failure on line %d\n", __LINE__); ret = 1; } while (0)
+#define CHK_FAIL_START \
+  chk_fail_ok = 1;                              \
+  if (! setjmp (chk_fail_buf))                  \
+    {
+#define CHK_FAIL_END \
+      chk_fail_ok = 0;                          \
+      FAIL ();                                  \
+    }

--- a/test_memcpy.c
+++ b/test_memcpy.c
@@ -1,5 +1,6 @@
 #include <string.h>
 #include <stdio.h>
+#include "test_common.c"
 
 /* reference implementation
  *
@@ -23,13 +24,18 @@
  */
 
 int main(int argc, char ** argv) {
+  int ret = 0;
   char buffer[3] = {0};
 #ifdef STATIC_CHECK
   memcpy(buffer, "yo", 4);
 #endif
   memcpy(buffer, "yo", 3);
   puts(buffer);
-  memcpy(buffer, "yo", argc);
+  if (argc > 1) {
+    CHK_FAIL_START
+    memcpy(buffer, "yo", argc);
+    CHK_FAIL_END
+  }
   puts(buffer);
-  return 0;
+  return ret;
 }

--- a/test_memmove.c
+++ b/test_memmove.c
@@ -1,5 +1,6 @@
 #include <string.h>
 #include <stdio.h>
+#include "test_common.c"
 
 /* reference implementation
  *
@@ -19,15 +20,21 @@
  * }
  */
 
+
 int main(int argc, char ** argv) {
   char buffer[3] = {0};
+  int ret = 0;
 #ifdef STATIC_CHECK
   memmove(buffer, "yo", 4);
 #endif
   memmove(buffer, "yo", 3);
   puts(buffer);
-  memmove(buffer, "yo", argc);
+  if (argc > 1) {
+    CHK_FAIL_START
+    memmove(buffer, "yo", argc);
+    CHK_FAIL_END
+  }
   puts(buffer);
-  return 0;
+  return ret;
 }
 

--- a/test_mempcpy.c
+++ b/test_mempcpy.c
@@ -1,6 +1,7 @@
 #define _GNU_SOURCE
 #include <string.h>
 #include <stdio.h>
+#include "test_common.c"
 
 /* reference implementation
  *
@@ -23,12 +24,17 @@
 
 int main(int argc, char ** argv) {
   char buffer[3] = {0};
+  int ret = 0;
 #ifdef STATIC_CHECK
   mempcpy(buffer, "yo", 4);
 #endif
   mempcpy(buffer, "yo", 3);
   puts(buffer);
-  mempcpy(buffer, "yo", argc);
+  if (argc > 1) {
+    CHK_FAIL_START
+    mempcpy(buffer, "yo", argc);
+    CHK_FAIL_END
+  }
   puts(buffer);
-  return 0;
+  return ret;
 }

--- a/test_memset.c
+++ b/test_memset.c
@@ -1,5 +1,6 @@
 #include <string.h>
 #include <stdio.h>
+#include "test_common.c"
 
 /* reference implementation
  *
@@ -28,13 +29,18 @@
 
 int main(int argc, char ** argv) {
   char buffer[3] = {0};
+  int ret = 0;
 #ifdef STATIC_CHECK
   memset(buffer, argc, 0);
   memset(buffer, 0, 4);
 #endif
   memset(buffer, 0, 3);
   puts(buffer);
-  memset(buffer, 0, argc);
+  if (argc > 1) {
+    CHK_FAIL_START
+    memset(buffer, 0, argc);
+    CHK_FAIL_END
+  }
   puts(buffer);
-  return 0;
+  return ret;
 }

--- a/test_snprintf.c
+++ b/test_snprintf.c
@@ -1,5 +1,6 @@
 #include <string.h>
 #include <stdio.h>
+#include "test_common.c"
 
 /* reference implementation
  *
@@ -31,12 +32,17 @@
 
 int main(int argc, char ** argv) {
   char buffer[3] = {0};
+  int ret = 0;
 #ifdef STATIC_CHECK
   snprintf(buffer, 4, "%d", argc);
 #endif
   snprintf(buffer, 3, "%d", argc);
   puts(buffer);
-  snprintf(buffer, argc, "%d", argc);
+  if (argc > 1) {
+    CHK_FAIL_START
+    snprintf(buffer, argc, "%d", argc);
+    CHK_FAIL_END
+  }
   puts(buffer);
   return 0;
 }

--- a/test_sprintf.c
+++ b/test_sprintf.c
@@ -1,6 +1,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include "test_common.c"
 
 /* reference implementation
  *
@@ -34,14 +35,19 @@
  */
 
 int main(int argc, char ** argv) {
+  int ret = 0;
   char buffer[3];
 #ifdef STATIC_CHECK
   sprintf(buffer, "hello");
 #endif
   // FIXME: no check for slen == 0
-  sprintf(buffer, "!%d", 8 + argc);
-  puts(buffer);
   sprintf(buffer, "%d", argc);
   puts(buffer);
-  return 0;
+  if (argc > 1) {
+    CHK_FAIL_START
+    sprintf(buffer, "!%d", 8 + argc);
+    CHK_FAIL_END
+  }
+  puts(buffer);
+  return ret;
 }

--- a/test_stpcpy.c
+++ b/test_stpcpy.c
@@ -2,6 +2,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include "test_common.c"
 
 /* reference implementation
  *
@@ -24,17 +25,23 @@
  */
 
 int main(int argc, char ** argv) {
+  int ret = 0;
   char buffer[3] = {0};
 #ifdef STATIC_CHECK
   stpcpy(buffer, "bonjour");
 #endif
   char from[] = "bonjour";
-  from[argc] = 0;
-  stpcpy(buffer, from);
-  puts(buffer);
 
   from[3] = 0;
   stpcpy(buffer, "yo");
   puts(buffer);
-  return 0;
+
+  from[argc] = 0;
+  if (argc > 1) {
+    CHK_FAIL_START
+    stpcpy(buffer, from);
+    CHK_FAIL_END
+  }
+  puts(buffer);
+  return ret;
 }

--- a/test_strcat.c
+++ b/test_strcat.c
@@ -1,6 +1,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include "test_common.c"
 
 /* reference implementation
  *
@@ -53,18 +54,22 @@ int main(int argc, char ** argv) {
   char from[] = "bonjour";
   if(argc == 5)
   {
+    CHK_FAIL_START
     char buffer[3] = {'a', 'b', 'c'};
     strcat(buffer, from);
     puts(buffer);
+    CHK_FAIL_END
   }
 
   from[argc] = 0;
 
   if(argc != 5)
   {
+    CHK_FAIL_START
     char buffer[3] = {0};
     strcat(buffer, from);
     puts(buffer);
+    CHK_FAIL_END
   }
 
 

--- a/test_strcpy.c
+++ b/test_strcpy.c
@@ -20,19 +20,25 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include "test_common.c"
 
 int main(int argc, char ** argv) {
   char buffer[3] = {0};
+  int ret = 0;
 #ifdef STATIC_CHECK
   strcpy(buffer, "bonjour");
 #endif
   char from[] = "bonjour";
-  from[argc] = 0;
-  strcpy(buffer, from);
-  puts(buffer);
+  if (argc > 1) {
+    CHK_FAIL_START
+    from[argc] = 0;
+    strcpy(buffer, from);
+    CHK_FAIL_END
+    puts(buffer);
+  }
 
   from[3] = 0;
   strcpy(buffer, "yo");
   puts(buffer);
-  return 0;
+  return ret;
 }

--- a/test_strncat.c
+++ b/test_strncat.c
@@ -75,24 +75,30 @@
  */
 #include <string.h>
 #include <stdio.h>
+#include "test_common.c"
 
 int main(int argc, char ** argv) {
   char buffer[3] = {0};
+  int ret = 0;
 #ifdef STATIC_CHECK
   strncat(buffer, "bonjour", 4);
 #endif
   if(argc >= 5)
   {
+    CHK_FAIL_START
     char buffer[5] = {'a', 'b', 'c', 'd', argc};
     strncat(buffer, "bonjour", argc);
+    CHK_FAIL_END
     puts(buffer);
   }
 
-  if(argc != 5)
+  if(argc > 1 && argc < 5)
   {
+    CHK_FAIL_START
     char buffer[3] = {0};
     strncat(buffer, "bonjour", argc);
     puts(buffer);
+    CHK_FAIL_END
   }
 
   {
@@ -100,5 +106,5 @@ int main(int argc, char ** argv) {
     strncat(buffer, "yo", 3);
     puts(buffer);
   }
-  return 0;
+  return ret;
 }

--- a/test_strncpy.c
+++ b/test_strncpy.c
@@ -1,5 +1,6 @@
 #include <string.h>
 #include <stdio.h>
+#include "test_common.c"
 
 /* reference implementation
  *
@@ -21,14 +22,17 @@
 
 int main(int argc, char ** argv) {
   char buffer[3] = {0};
+  int ret = 0;
 #ifdef STATIC_CHECK
   strncpy(buffer, "bonjour", 4);
 #endif
 
-  {
+  if (argc > 1) {
+    CHK_FAIL_START
     char buffer[3] = {0};
     strncpy(buffer, "bonjour", argc);
     puts(buffer);
+    CHK_FAIL_END
   }
 
   {
@@ -36,5 +40,5 @@ int main(int argc, char ** argv) {
     strncpy(buffer, "yo", 3);
     puts(buffer);
   }
-  return 0;
+  return ret;
 }

--- a/test_vsnprintf.c
+++ b/test_vsnprintf.c
@@ -1,6 +1,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdarg.h>
+#include "test_common.c"
 
 /* reference implementation
  * int
@@ -26,6 +27,7 @@
 
 int aux(int argc, char ** argv, ...) {
   char buffer[3] = {0};
+  int ret = 0;
   va_list ap;
   va_start(ap, argv);
 
@@ -35,10 +37,14 @@ int aux(int argc, char ** argv, ...) {
 #endif
   vsnprintf(buffer, 3, "%d", ap);
   puts(buffer);
-  vsnprintf(buffer, argc, "%d", ap);
+  if (argc > 1) {
+    CHK_FAIL_START
+    vsnprintf(buffer, argc, "%d", ap);
+    CHK_FAIL_END
+  }
   puts(buffer);
   va_end(ap);
-  return 0;
+  return ret;
 }
 
 int main(int argc, char ** argv) {

--- a/test_vsprintf.c
+++ b/test_vsprintf.c
@@ -26,6 +26,7 @@
 #include <string.h>
 #include <stdarg.h>
 #include <stdio.h>
+#include "test_common.c"
 
 int aux0(int argc, char ** argv, ...) {
   va_list ap;
@@ -39,12 +40,17 @@ int aux0(int argc, char ** argv, ...) {
 }
 int aux1(int argc, char ** argv, ...) {
   va_list ap;
+  int ret = 0;
   va_start(ap, argv);
   char buffer[3];
-  vsprintf(buffer, "!%d", ap);
+  if (argc > 1) {
+    CHK_FAIL_START
+    vsprintf(buffer, "!%d", ap);
+    CHK_FAIL_END
+  }
   puts(buffer);
   va_end(ap);
-  return 0;
+  return ret;
 }
 int aux2(int argc, char ** argv, ...) {
   va_list ap;


### PR DESCRIPTION
This goes on top of #4

Use the glibc idea to handle SIGABRT generated by the fortify check
failure.  This way, all test invocations must succeed and the make
output also becomes a lot cleaner.